### PR TITLE
Small adjustments to ensure portable C code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+-include CONFIGURE
+CFLAGS ?= -Wall
+
 LDOC= 	lua util/ldoc.lua
 
 DOCS=	docs/quadrules.qmd \
@@ -31,14 +34,16 @@ TESTS=	exe/test_quad.x \
 
 all:
 
+objs:  $(OBJS)
+
 obj/%.o: src/%.c
-	gcc -Wall -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 obj/%.o: test/%.c
-	gcc -Wall -Isrc -c $< -o $@
+	$(CC) $(CFLAGS) -Isrc -c $< -o $@
 
 exe/%.x: obj/%.o $(OBJS)
-	gcc -Wall -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^
 
 docs/%.qmd: src/%.h src/%.c
 	$(LDOC) -highlight c -p quarto -o $@ $^
@@ -72,7 +77,7 @@ src/bandmat.o: src/vecmat.h src/bandmat.h
 src/element.o: src/shapes.h src/quadrules.h src/assemble.h src/mesh.h
 src/element.o: src/fem.h src/element.h
 src/fem.o: src/assemble.h src/element.h src/bandmat.h src/mesh.h src/shapes.h
-src/fem.o: src/fem.h
+src/fem.o: src/fem.h src/element.h
 src/quadrules.o: src/quadrules.h
 src/mesh.o: src/mesh.h src/shapes.h
 src/shapes.o: src/shapes.h

--- a/src/assemble.c
+++ b/src/assemble.c
@@ -27,9 +27,9 @@ void assemble_clear(assemble_t* assembler)
  * 
  */
 // Declare private implementations for the methods
-static void assemble_dense_add(void* p, double* emat, int* ids, int ne);
-static void assemble_bandmat_add(void* p, double* emat, int* ids, int ne);
-static void assemble_vecmat_clear(void* p);
+/*static*/ void assemble_dense_add(void* p, double* emat, int* ids, int ne);
+/*static*/ void assemble_bandmat_add(void* p, double* emat, int* ids, int ne);
+/*static*/ void assemble_vecmat_clear(void* p);
 
 // Initialize a dense assembler
 void init_assemble_dense(assemble_t* assembler, double* A)
@@ -55,7 +55,7 @@ void init_assemble_band(assemble_t* assembler, double* b)
  * where the global indices are negative (indicating that these
  * contributions are not needed because of an essential boundary condition.
  */
-static void assemble_dense_add(void* p, double* emat, int* ids, int ne)
+/*static*/ void assemble_dense_add(void* p, double* emat, int* ids, int ne)
 {
     vecmat_head_t* head = vecmat(p);
     double* A = head->data;
@@ -71,7 +71,7 @@ static void assemble_dense_add(void* p, double* emat, int* ids, int ne)
     }
 }
 
-static void assemble_bandmat_add(void* p, double* emat, int* ids, int ne)
+/*static*/ void assemble_bandmat_add(void* p, double* emat, int* ids, int ne)
 {
     vecmat_head_t* head = vecmat(p);
     double* P = head->data;
@@ -94,7 +94,7 @@ static void assemble_bandmat_add(void* p, double* emat, int* ids, int ne)
 /**
  * ## Clearing storage
  */
-static void assemble_vecmat_clear(void* p)
+/*static*/ void assemble_vecmat_clear(void* p)
 {
     vecmat_clear((double*) p);
 }

--- a/src/element.c
+++ b/src/element.c
@@ -54,14 +54,14 @@ typedef struct poisson_elt_t {
 } poisson_elt_t;
 
 // Declare methods for 1D and 2D Poisson element types
-static void poisson1d_elt_dR(void* p, fem_t* fe, int eltid,
+/*static*/ void poisson1d_elt_dR(void* p, fem_t* fe, int eltid,
                              double* Re, double* Ke);
-static void poisson2d_elt_dR(void* p, fem_t* fe, int eltid,
+/*static*/ void poisson2d_elt_dR(void* p, fem_t* fe, int eltid,
                              double* Re, double* Ke);
-static void simple_elt_free(void* p);
+/*static*/ void simple_elt_free(void* p);
 
 // Allocate a 1D Poisson element type
-element_t* malloc_poisson1d_element()
+element_t* malloc_poisson1d_element(void)
 {
     poisson_elt_t* le = (poisson_elt_t*) malloc(sizeof(poisson_elt_t));
     le->e.p = le;
@@ -71,7 +71,7 @@ element_t* malloc_poisson1d_element()
 }
 
 // Allocate a 2D Poisson element type
-element_t* malloc_poisson2d_element()
+element_t* malloc_poisson2d_element(void)
 {
     poisson_elt_t* le = (poisson_elt_t*) malloc(sizeof(poisson_elt_t));
     le->e.p = le;
@@ -81,7 +81,7 @@ element_t* malloc_poisson2d_element()
 }
 
 // Free a Poisson element type
-static void simple_elt_free(void* p)
+/*static*/ void simple_elt_free(void* p)
 {
     free(p);
 }
@@ -115,7 +115,7 @@ static void simple_elt_free(void* p)
  * domain, and the weights are multiplied by the Jacobian determinant for this
  * computation.
  */
-static void poisson1d_elt_dR(
+/*static*/ void poisson1d_elt_dR(
     void* p,                   // Context pointer (not used)
     fem_t* fe, int eltid,      // Mesh and element ID in mesh
     double* Re, double* Ke)    // Outputs: element residual and tangent
@@ -171,7 +171,7 @@ static void poisson1d_elt_dR(
  * The one thing that is a little different is that we will do a little
  * more work to get an appropriate quadrature rule.
  */
-static int get_quad2d(shapes_t shapefn,
+/*static*/ int get_quad2d(shapes_t shapefn,
                       void (**quad_pt)(double*, int, int),
                       double (**quad_wt)(int, int))
 {
@@ -195,7 +195,7 @@ static int get_quad2d(shapes_t shapefn,
         assert(0);
 }
 
-static void poisson2d_elt_dR(
+/*static*/ void poisson2d_elt_dR(
     void* p,                   // Context pointer (not used)
     fem_t* fe, int eltid,      // Mesh and element ID in mesh
     double* Re, double* Ke)    // Outputs: element residual and tangent

--- a/src/element.h
+++ b/src/element.h
@@ -67,8 +67,8 @@ void free_element(element_t* e);
  * There are no PDE coefficients or other special parameters to keep 
  * track of for this element tyle.
  */
-element_t* malloc_poisson1d_element();
-element_t* malloc_poisson2d_element();
+element_t* malloc_poisson1d_element(void);
+element_t* malloc_poisson2d_element(void);
 
 //ldoc off
 #endif /* ELEMENT_H */

--- a/src/quadrules.c
+++ b/src/quadrules.c
@@ -171,7 +171,7 @@ double gauss_weight(int i, int npts)
 /**
  * ## Implementation
  */
-static int gauss2d_npoint1d(int npts)
+/*static*/ int gauss2d_npoint1d(int npts)
 {
     switch (npts) {
     case  1: return 1;

--- a/src/vecmat.c
+++ b/src/vecmat.c
@@ -330,7 +330,7 @@ double vecmatn_norm2(double* data, int n)
         double xj = data[j];
         result += xj*xj;
     }
-    return sqrt(result);
+    return result;
 }
 
 double vecmatn_norm(double* data, int n)

--- a/src/vecmat.c
+++ b/src/vecmat.c
@@ -18,7 +18,7 @@
 vecmat_head_t* vecmat(double* data)
 {
     vecmat_head_t dummy;
-    void* p = (void*) data + ((void*) &dummy - (void*) dummy.data);
+    void* p = (char*) data + ((char*) &dummy - (char*) dummy.data);
     return (vecmat_head_t*) p;
 }
 

--- a/test/test_assemble.c
+++ b/test/test_assemble.c
@@ -14,7 +14,7 @@ void test_K_setup(assemble_t* assembler)
     ids[0] = 1; ids[1] = 2; assemble_add(assembler, emat, ids, 2);
 }
 
-void test_Kassembly()
+void test_Kassembly(void)
 {
     double* A = malloc_vecmat(3,3);
     double* P = malloc_bandmat(3,1);
@@ -38,7 +38,7 @@ void test_Kassembly()
     free_vecmat(A);
 }
 
-void test_Rassembly()
+void test_Rassembly(void)
 {
     double* v = malloc_vecmat(3,1);
     double ve[] = {1.0, -1.0};
@@ -52,7 +52,7 @@ void test_Rassembly()
     free_vecmat(v);
 }
 
-int main()
+int main(void)
 {
     test_Kassembly();
     test_Rassembly();

--- a/test/test_fem1d.c
+++ b/test/test_fem1d.c
@@ -87,7 +87,7 @@ void test_fem2(int d)
     free_fem(fe);
 }
 
-int main()
+int main(void)
 {
     for (int d = 1; d <= 3; ++d)
         test_fem1(d);

--- a/test/test_fem2d.c
+++ b/test/test_fem2d.c
@@ -13,7 +13,7 @@
 
 
 // Set up the mesh on [0,1]^2 with Dirichlet BC
-void test_fem1()
+void test_fem1(void)
 {
     mesh_t* mesh = mesh_block2d_P1(2, 2);
     fem_t* fe = malloc_fem(mesh, 1);
@@ -56,7 +56,7 @@ void test_fem1()
     free_fem(fe);
 }
 
-int main()
+int main(void)
 {
     test_fem1();
     return 0;

--- a/test/test_mesh.c
+++ b/test/test_mesh.c
@@ -102,7 +102,7 @@ void check_mesh(mesh_t* mesh,
         assert(eref[i] == mesh->elt[i]);
 }
 
-void test_block_meshers()
+void test_block_meshers(void)
 {
     mesh_t* mesh = mesh_block2d_P1(3,2);
     check_mesh(mesh, 12, XrefP1, 6, 4, erefP1);
@@ -129,7 +129,7 @@ void test_block_map(double* xy)
     xy[1] = 1.0 + x+y;
 }
 
-void test_emap()
+void test_emap(void)
 {
     int ipiv[2];
     double N[4], dN[4*2], xymap[2], J[2*2];
@@ -154,7 +154,7 @@ void test_emap()
     free_mesh(mesh);
 }
 
-int main()
+int main(void)
 {
     test_block_meshers();
     test_emap();

--- a/test/test_quad.c
+++ b/test/test_quad.c
@@ -4,7 +4,7 @@
 
 #include "quadrules.h"
 
-void test_gauss1d()
+void test_gauss1d(void)
 {
     // Should be exact on polynomials of degree 2k-1
     // Test on x^5 + 3x^4 - x^3 + x^2 + x + 1
@@ -24,7 +24,7 @@ void test_gauss1d()
     }
 }
 
-void test_gauss2d()
+void test_gauss2d(void)
 {
     for (int d = 1; d < 5; ++d) {
         int npts = d*d;
@@ -47,7 +47,7 @@ void test_gauss2d()
     }
 }
 
-void test_hughes()
+void test_hughes(void)
 {
     int npts = 3;
     double Iref[] = {0.5, 1.0/6, 1.0/6, 1.0/24};
@@ -68,7 +68,7 @@ void test_hughes()
     }
 }
 
-int main()
+int main(void)
 {
     test_gauss1d();
     test_gauss2d();

--- a/test/test_vecmat.c
+++ b/test/test_vecmat.c
@@ -5,7 +5,7 @@
 
 #include "vecmat.h"
 
-int main()
+int main(void)
 {
     int ipiv[3];
     double* x = malloc_vecmat(3, 1);


### PR DESCRIPTION
1. Makefile adjustments.
   - Allow specification of an alternate C compiler instead of gcc
     (e.g., with an optional CONFIGURE file containing   CC=ccomp)
   - Allow specification of CFLAGS (e.g., in configure file)
   - add "objs" target

2. C hygiene
   - Change old-style function prototypes 'int foo()' to new-style 'int foo(void)'
   - Avoid pointer arithmetic on (void*), use (char*) instead
   - Don't use static functions, which is legal C but no fun in VST as name-munged by compiler

3.  Bug fix
    - remove inappropriate sqrt in vecmatn_norm