### PR TITLE
Make typedefs be pointers; propose setters/getters for matrices

### DIFF
--- a/src/assemble.c
+++ b/src/assemble.c
@@ -10,26 +10,26 @@
 /**
  * ## Method dispatch
  */
-void assemble_add(assemble_t* assembler, double* emat, int* ids, int ne)
+void assemble_add(assemble_t assembler, double* emat, int* ids, int ne)
 {
     (*(assembler->add))(assembler->p, emat, ids, ne);
 }
 
-void assemble_clear (assemble_t *assembler)
+void assemble_clear (assemble_t assembler)
 {
     (*(assembler->clear))(assembler->p);
 }
 
-double assemble_norm2 (assemble_t *assembler)
+double assemble_norm2 (assemble_t assembler)
 {
    return (*(assembler->norm2))(assembler->p);
 }
 
-double assemble_norm (assemble_t *assembler) {
+double assemble_norm (assemble_t assembler) {
   return sqrt(assemble_norm2(assembler));
 }
 
-void assemble_print (assemble_t *assembler)
+void assemble_print (assemble_t assembler)
 {
     (*(assembler->print))(assembler->p);
 }
@@ -42,25 +42,25 @@ void assemble_print (assemble_t *assembler)
  * 
  */
 // Declare private implementations for the methods
-/*static*/ void assemble_dense_add(assemble_data_t* p, double* emat, int* ids, int ne);
-/*static*/ void assemble_bandmat_add(assemble_data_t* p, double* emat, int* ids, int ne);
+/*static*/ void assemble_dense_add(assemble_data_t p, double* emat, int* ids, int ne);
+/*static*/ void assemble_bandmat_add(assemble_data_t p, double* emat, int* ids, int ne);
 
 // Initialize a dense assembler
-void casted_densemat_clear(assemble_data_t *p) {
-  densemat_clear ((densemat_t*)p);
+void casted_densemat_clear(assemble_data_t p) {
+  densemat_clear ((densemat_t)p);
 }
 
-double casted_densemat_norm2(assemble_data_t *p) {
-  return densemat_norm2 ((densemat_t*)p);
+double casted_densemat_norm2(assemble_data_t p) {
+  return densemat_norm2 ((densemat_t)p);
 }
 
-void casted_densemat_print(assemble_data_t *p) {
-  densemat_print ((densemat_t*)p);
+void casted_densemat_print(assemble_data_t p) {
+  densemat_print ((densemat_t)p);
 }
 
-void init_assemble_dense(assemble_t* assembler, densemat_t* A)
+void init_assemble_dense(assemble_t assembler, densemat_t A)
 {
-    assembler->p = (assemble_data_t*)A;
+    assembler->p = (assemble_data_t)A;
     assembler->add = assemble_dense_add;
     assembler->clear = casted_densemat_clear;
     assembler->norm2 = casted_densemat_norm2;
@@ -68,21 +68,21 @@ void init_assemble_dense(assemble_t* assembler, densemat_t* A)
 }
 
 // Initialize a band assembler
-void casted_bandmat_clear(assemble_data_t *p) {
-  bandmat_clear ((bandmat_t*)p);
+void casted_bandmat_clear(assemble_data_t p) {
+  bandmat_clear ((bandmat_t)p);
 }
 
-double casted_bandmat_norm2(assemble_data_t *p) {
-  return bandmat_norm2 ((bandmat_t*)p);
+double casted_bandmat_norm2(assemble_data_t p) {
+  return bandmat_norm2 ((bandmat_t)p);
 }
 
-void casted_bandmat_print(assemble_data_t *p) {
-  bandmat_print ((bandmat_t*)p);
+void casted_bandmat_print(assemble_data_t p) {
+  bandmat_print ((bandmat_t)p);
 }
 
-void init_assemble_band(assemble_t* assembler, bandmat_t* b)
+void init_assemble_band(assemble_t assembler, bandmat_t b)
 {
-    assembler->p = (assemble_data_t*)b;
+    assembler->p = (assemble_data_t)b;
     assembler->add = assemble_bandmat_add;
     assembler->clear = casted_bandmat_clear;
     assembler->norm2 = casted_bandmat_norm2;
@@ -97,9 +97,9 @@ void init_assemble_band(assemble_t* assembler, bandmat_t* b)
  * where the global indices are negative (indicating that these
  * contributions are not needed because of an essential boundary condition.
  */
-/*static*/ void assemble_dense_add(assemble_data_t* p, double* emat, int* ids, int ne)
+/*static*/ void assemble_dense_add(assemble_data_t p, double* emat, int* ids, int ne)
 {
-    densemat_t *A = (densemat_t*)p;
+    densemat_t A = (densemat_t)p;
     int n = A->m;
 
     for (int je = 0; je < ne; ++je) {
@@ -112,9 +112,9 @@ void init_assemble_band(assemble_t* assembler, bandmat_t* b)
     }
 }
 
-/*static*/ void assemble_bandmat_add(assemble_data_t* p, double* emat, int* ids, int ne)
+/*static*/ void assemble_bandmat_add(assemble_data_t p, double* emat, int* ids, int ne)
 {
-    bandmat_t *P = (bandmat_t *)p;
+    bandmat_t P = (bandmat_t)p;
     int n = P->m;
     int b = P->b;
 

--- a/src/assemble.h
+++ b/src/assemble.h
@@ -76,21 +76,21 @@
  * 
  */
 // Interface for general assembler object (callback + context)
-typedef struct assemble_data_t assemble_data_t;
+typedef struct assemble_data_t *assemble_data_t;
 
 typedef struct assemble_t {
-    assemble_data_t* p;                            // Context
-    void (*add)(assemble_data_t*, double*, int*, int); // Add contribution
-    void (*clear)(assemble_data_t*); // set to zero
-    double (*norm2)(assemble_data_t*); // square of Frobenius norm
-    void (*print)(assemble_data_t*);
-} assemble_t;
+    assemble_data_t p;                            // Context
+    void (*add)(assemble_data_t, double*, int*, int); // Add contribution
+    void (*clear)(assemble_data_t); // set to zero
+    double (*norm2)(assemble_data_t); // square of Frobenius norm
+    void (*print)(assemble_data_t);
+} *assemble_t;
 
 // Convenience functions that call the assembler methods
-void assemble_add(assemble_t* assembler, double* emat, int* ids, int ne);
-void assemble_clear(assemble_t *assembler);
-double assemble_norm2(assemble_t *assembler);
-void assemble_print(assemble_t *assembler);
+void assemble_add(assemble_t assembler, double* emat, int* ids, int ne);
+void assemble_clear(assemble_t assembler);
+double assemble_norm2(assemble_t assembler);
+void assemble_print(assemble_t assembler);
 
 /**
  * We currently only support two types of assemblers: dense and band.
@@ -100,8 +100,8 @@ void assemble_print(assemble_t *assembler);
  * that are outside the band (and error out if a contribution does live
  * outside the expected band).
  */
-void init_assemble_dense(assemble_t* assembler, densemat_t* A);
-void init_assemble_band(assemble_t* assembler, bandmat_t* b);
+void init_assemble_dense(assemble_t assembler, densemat_t A);
+void init_assemble_band(assemble_t assembler, bandmat_t b);
 
 /**
  * ## Vector assembly interface

--- a/src/bandmat.c
+++ b/src/bandmat.c
@@ -13,18 +13,18 @@
  * 
  */
 // Allocate a band matrix
-bandmat_t* bandmat_malloc(int n, int b)
+bandmat_t bandmat_malloc(int n, int b)
 {
-  bandmat_t *vm = surely_malloc(sizeof(bandmat_t) + (n*(b+1))*sizeof(double));
+  bandmat_t vm = surely_malloc(sizeof(struct bandmat_t) + (n*(b+1))*sizeof(double));
   vm->m=n; vm->b=b;
   return vm;
 }
 
 // Convert dense n-by-n A to band matrix P with bandwidth bw
-bandmat_t* dense_to_band(densemat_t* A, int bw)
+bandmat_t dense_to_band(densemat_t A, int bw)
 {
     int n = A->n;
-    bandmat_t* P = bandmat_malloc(n, bw);
+    bandmat_t P = bandmat_malloc(n, bw);
     for (int d = 0; d <= bw; ++d)
         for (int j = d; j < n; ++j) {
             int i = j-d;
@@ -33,7 +33,7 @@ bandmat_t* dense_to_band(densemat_t* A, int bw)
     return P;
 }
 
-void bandmat_free(bandmat_t* vm)
+void bandmat_free(bandmat_t vm)
 {
     free(vm);
 }
@@ -43,7 +43,7 @@ void bandmatn_clear(double* data, int m, int b)
   memset(data, 0, (m*(b+1)) * sizeof(double));
 }
 
-void bandmat_clear(bandmat_t* vm)
+void bandmat_clear(bandmat_t vm)
 {
   bandmatn_clear(vm->data, vm->m, vm->b);
 }
@@ -63,7 +63,7 @@ void bandmat_clear(bandmat_t* vm)
  * 
  */
 // Print band format array
-void bandmat_print(bandmat_t* PA)
+void bandmat_print(bandmat_t PA)
 {
     int n = PA->m, bw = PA->b;
 
@@ -92,7 +92,7 @@ void bandmat_print(bandmat_t* PA)
  * (violating the assumption of positive definiteness).
  * 
  */
-void bandmat_factor(bandmat_t* PA)
+void bandmat_factor(bandmat_t PA)
 {
     int n = PA->m, bw=PA->b;
     
@@ -120,7 +120,7 @@ void bandmat_factor(bandmat_t* PA)
  * on input the `x` argument should be set to the system right-hand side,
  * and on output it will be the solution vector.
  */
-void bandmat_solve(bandmat_t* PR, double* x)
+void bandmat_solve(bandmat_t PR, double* x)
 {
     int n = PR->m, bw = PR->b;
     
@@ -145,12 +145,12 @@ void bandmat_solve(bandmat_t* PR, double* x)
  * ## Norm computations
  */
 
-double bandmat_norm2(bandmat_t* vm)
+double bandmat_norm2(bandmat_t vm)
 {
   return data_norm2(vm->data, vm->m*(vm->b+1));
 }
 
-double bandmat_norm(bandmat_t* vm)
+double bandmat_norm(bandmat_t vm)
 {
   return data_norm(vm->data, vm->m*(vm->b+1));
 }

--- a/src/bandmat.h
+++ b/src/bandmat.h
@@ -21,30 +21,30 @@
 typedef struct bandmat_t {
     int m,b;  // rows, bands
     double data[0];  // Start of data array
-} bandmat_t;
+} *bandmat_t;
 
 // Allocate a new bandmat (and maybe populate from a dense matrix)
-bandmat_t* bandmat_malloc(int n, int b);
-void bandmat_free(bandmat_t* vm);
-bandmat_t* dense_to_band(densemat_t* A, int bw);
+bandmat_t bandmat_malloc(int n, int b);
+void bandmat_free(bandmat_t vm);
+bandmat_t dense_to_band(densemat_t A, int bw);
 
 // Clear
 
 void bandmatn_clear(double* data, int m, int b);
-void bandmat_clear(bandmat_t* vm);
+void bandmat_clear(bandmat_t vm);
 
 
 // Print a bandmat
-void bandmat_print(bandmat_t* PA);
+void bandmat_print(bandmat_t PA);
 
 // Frobenius norm-squared and norm 
-double bandmat_norm2(bandmat_t* vm);
-double bandmat_norm(bandmat_t* vm);
+double bandmat_norm2(bandmat_t vm);
+double bandmat_norm(bandmat_t vm);
 
 
 // Cholesky and linear solve with Cholesky
-void bandmat_factor(bandmat_t* PA);
-void bandmat_solve(bandmat_t* PR, double* x);
+void bandmat_factor(bandmat_t PA);
+void bandmat_solve(bandmat_t PR, double* x);
 
 //ldoc off
 #endif /* BANDMAT_H */

--- a/src/densemat.c
+++ b/src/densemat.c
@@ -14,15 +14,15 @@
  * (which contains the first entry in the data array) along with space
  * for the remainder of the `m*n` double precision numbers in the data array.  
  */
-densemat_t* densemat_malloc(int m, int n)
+densemat_t densemat_malloc(int m, int n)
 {
-    densemat_t* h = surely_malloc(sizeof(densemat_t) + (m*n)*sizeof(double));
+    densemat_t h = surely_malloc(sizeof(struct densemat_t) + (m*n)*sizeof(double));
     h->m=m;
     h->n=n;
     return h;
 }
 
-void densemat_free(densemat_t* vm)
+void densemat_free(densemat_t vm)
 {
     free(vm);
 }
@@ -32,7 +32,7 @@ void densematn_clear(double* data, int m, int n)
   double_clear(data,m*n);
 }
 
-void densemat_clear(densemat_t* vm)
+void densemat_clear(densemat_t vm)
 {
   densematn_clear(vm->data, vm->m, vm->n);
 }
@@ -56,7 +56,7 @@ void densematn_print(double* data, int m, int n)
     }
 }
 
-void densemat_print(densemat_t* vm)
+void densemat_print(densemat_t vm)
 {
     densematn_print(vm->data, vm->m, vm->n);
 }
@@ -96,7 +96,7 @@ void densematn_cfactor(double* A, int n)
 }
 
 //ldoc off
-void densemat_cfactor(densemat_t* A)
+void densemat_cfactor(densemat_t A)
 {
     assert(A->m == A->n);
     densematn_cfactor(A->data, A->m);
@@ -129,7 +129,7 @@ void densematn_csolve(double* R, double* x, int n)
 }
 
 //ldoc off
-void densemat_csolve(densemat_t* R, double* x)
+void densemat_csolve(densemat_t R, double* x)
 {
     densematn_csolve(R->data, x, R->n);
 }
@@ -269,23 +269,23 @@ double densematn_lujac(int* ipiv, double* A, int n)
  * autodoc output.
  */
 
-void densemat_lufactor(int* ipiv, densemat_t* A)
+void densemat_lufactor(int* ipiv, densemat_t A)
 {
     assert(A->m == A->n);
     densematn_lufactor(ipiv, A->data, A->m);
 }
 
-void densemat_lusolve(int* ipiv, densemat_t* A, double* x)
+void densemat_lusolve(int* ipiv, densemat_t A, double* x)
 {
     densematn_lusolve(ipiv, A->data, x, A->m);
 }
 
-void densemat_lusolveT(int* ipiv, densemat_t* A, double* x)
+void densemat_lusolveT(int* ipiv, densemat_t A, double* x)
 {
     densematn_lusolveT(ipiv, A->data, x, A->m);
 }
 
-double densemat_lujac(int* ipiv, densemat_t* A)
+double densemat_lujac(int* ipiv, densemat_t A)
 {
     return densematn_lujac(ipiv, A->data, A->m);
 }
@@ -314,12 +314,12 @@ double data_norm(double* data, int n)
     return sqrt(data_norm2(data, n));
 }
 
-double densemat_norm2(densemat_t* vm)
+double densemat_norm2(densemat_t vm)
 {
     return data_norm2(vm->data, vm->m*vm->n);
 }
 
-double densemat_norm(densemat_t* vm)
+double densemat_norm(densemat_t vm)
 {
     return data_norm(vm->data, vm->m*vm->n);
 }

--- a/src/densemat.h
+++ b/src/densemat.h
@@ -14,43 +14,47 @@
 typedef struct densemat_t {
     int m,n;  // rows, columns
     double data[0];  // Start of data array
-} densemat_t;
+} *densemat_t;
 
 // Create and free 
-densemat_t* densemat_malloc(int m, int n);
-void densemat_free(densemat_t* dm);
+densemat_t densemat_malloc(int m, int n);
+void densemat_free(densemat_t dm);
 
 // Clear storage
 void densematn_clear(double* data, int m, int n);
-void densemat_clear(densemat_t* dm);
+void densemat_clear(densemat_t dm);
 
 // Print array (assumes column major order)
 void densematn_print(double* data, int m, int n);
-void densemat_print(densemat_t* data);
+void densemat_print(densemat_t data);
 
 // Cholesky factorization and solve (uses only upper triangular)
 void densematn_cfactor(double* A, int n);
 void densematn_csolve(double* R, double* x, int n);
-void densemat_cfactor(densemat_t* A);
-void densemat_csolve(densemat_t* R, double* x);
+void densemat_cfactor(densemat_t A);
+void densemat_csolve(densemat_t R, double* x);
 
 // LU factorization and solve
 void densematn_lufactor(int* ipiv, double* A, int n);
 void densematn_lusolve(int* ipiv, double* A, double* x, int n);
 void densematn_lusolveT(int* ipiv, double* A, double* x, int n);
-void densemat_lufactor(int* ipiv, densemat_t* A);
-void densemat_lusolve(int* ipiv, densemat_t* A, double* x);
-void densemat_lusolveT(int* ipiv, densemat_t* A, double* x);
+void densemat_lufactor(int* ipiv, densemat_t A);
+void densemat_lusolve(int* ipiv, densemat_t A, double* x);
+void densemat_lusolveT(int* ipiv, densemat_t A, double* x);
 
 // Jacobian determinant from LU factorization
 double densematn_lujac(int* ipiv, double* A, int n);
-double densemat_lujac(int* ipiv, densemat_t* A);
+double densemat_lujac(int* ipiv, densemat_t A);
 
 // Squared norm and norm computations
 double data_norm2(double* data, int n);
 double data_norm(double* data, int n);
-double densemat_norm2(densemat_t* dm);
-double densemat_norm(densemat_t* dm);
+double densemat_norm2(densemat_t dm);
+double densemat_norm(densemat_t dm);
+
+double densemat_get(densemat_t dm, int i, int j);
+void densemat_set(densemat_t dm, int i, int j, double x);
+void densemat_addto(densemat_t dm, int i, int j, double x);
 
 //ldoc off
 #endif /* DENSEMAT_H */

--- a/src/element.c
+++ b/src/element.c
@@ -19,14 +19,14 @@
  * pointer in an element object's dispatch table.
  */
 // Call element dR method
-void element_dR(element_t* e, struct fem_t* fe, int eltid,
+void element_dR(element_t e, fem_t fe, int eltid,
                 double* Re, double* Ke)
 {
     (*(e->dR))(e->p, fe, eltid, Re, Ke);
 }
 
 // Call element free
-void element_free(element_t* e)
+void element_free(element_t e)
 {
     (*(e->free))(e->p);
 }
@@ -50,20 +50,20 @@ void element_free(element_t* e)
 // Poisson element type data structure
 typedef struct poisson_elt_t {
     // Material parameters, etc go here in more complex cases
-    element_t e; // For dispatch table
-} poisson_elt_t;
+    struct element_t e; // For dispatch table
+} *poisson_elt_t;
 
 // Declare methods for 1D and 2D Poisson element types
-/*static*/ void poisson1d_elt_dR(void* p, fem_t* fe, int eltid,
+/*static*/ void poisson1d_elt_dR(void* p, fem_t fe, int eltid,
                              double* Re, double* Ke);
-/*static*/ void poisson2d_elt_dR(void* p, fem_t* fe, int eltid,
+/*static*/ void poisson2d_elt_dR(void* p, fem_t fe, int eltid,
                              double* Re, double* Ke);
 /*static*/ void simple_elt_free(void* p);
 
 // Allocate a 1D Poisson element type
-element_t* malloc_poisson1d_element(void)
+element_t malloc_poisson1d_element(void)
 {
-    poisson_elt_t* le = (poisson_elt_t*) surely_malloc(sizeof(poisson_elt_t));
+    poisson_elt_t le = (poisson_elt_t) surely_malloc(sizeof(struct poisson_elt_t));
     le->e.p = le;
     le->e.dR = poisson1d_elt_dR;
     le->e.free = simple_elt_free;
@@ -71,9 +71,9 @@ element_t* malloc_poisson1d_element(void)
 }
 
 // Allocate a 2D Poisson element type
-element_t* malloc_poisson2d_element(void)
+element_t malloc_poisson2d_element(void)
 {
-    poisson_elt_t* le = (poisson_elt_t*) surely_malloc(sizeof(poisson_elt_t));
+    poisson_elt_t le = (poisson_elt_t) surely_malloc(sizeof(struct poisson_elt_t));
     le->e.p = le;
     le->e.dR = poisson2d_elt_dR;
     le->e.free = simple_elt_free;
@@ -117,7 +117,7 @@ element_t* malloc_poisson2d_element(void)
  */
 /*static*/ void poisson1d_elt_dR(
     void* p,                   // Context pointer (not used)
-    fem_t* fe, int eltid,      // Mesh and element ID in mesh
+    fem_t fe, int eltid,      // Mesh and element ID in mesh
     double* Re, double* Ke)    // Outputs: element residual and tangent
 {
     int nen  = fe->mesh->nen;
@@ -198,7 +198,7 @@ element_t* malloc_poisson2d_element(void)
 
 /*static*/ void poisson2d_elt_dR(
     void* p,                   // Context pointer (not used)
-    fem_t* fe, int eltid,      // Mesh and element ID in mesh
+    fem_t fe, int eltid,      // Mesh and element ID in mesh
     double* Re, double* Ke)    // Outputs: element residual and tangent
 {
     int nen  = fe->mesh->nen;

--- a/src/element.h
+++ b/src/element.h
@@ -48,12 +48,12 @@ typedef struct element_t {
     void (*dR)(void* p, struct fem_t* fe, int eltid,
               double* Re, double* Ke);
     void (*free)(void* p);
-} element_t;
+} *element_t;
 
 // Wrappers for calling the dR and free method
-void element_dR(element_t* e, struct fem_t* fe, int eltid,
+void element_dR(element_t e, struct fem_t* fe, int eltid,
                 double* Re, double* Ke);
-void element_free(element_t* e);
+void element_free(element_t e);
 
 /**
  * Write now, we only have one element type, corresponding to a 1D Poisson
@@ -67,8 +67,8 @@ void element_free(element_t* e);
  * There are no PDE coefficients or other special parameters to keep 
  * track of for this element tyle.
  */
-element_t* malloc_poisson1d_element(void);
-element_t* malloc_poisson2d_element(void);
+element_t malloc_poisson1d_element(void);
+element_t malloc_poisson2d_element(void);
 
 //ldoc off
 #endif /* ELEMENT_H */

--- a/src/fem.c
+++ b/src/fem.c
@@ -14,11 +14,11 @@
  * ## Implementation
  */
 // Allocate mesh object
-fem_t* fem_malloc(mesh_t* mesh, int ndof)
+fem_t fem_malloc(mesh_t mesh, int ndof)
 {
     int numnp = mesh->numnp;
 
-    fem_t* fe = surely_malloc(sizeof(fem_t));
+    fem_t fe = surely_malloc(sizeof(struct fem_t));
     fe->mesh    = mesh;
     fe->etype   = NULL;
     fe->ndof    = ndof;
@@ -32,7 +32,7 @@ fem_t* fem_malloc(mesh_t* mesh, int ndof)
 }
 
 // Free mesh object
-void fem_free(fem_t* fe)
+void fem_free(fem_t fe)
 {
     free(fe->id);
     free(fe->F);
@@ -42,7 +42,7 @@ void fem_free(fem_t* fe)
 }
 
 // Initialize the id array and set nactive
-int fem_assign_ids(fem_t* fe)
+int fem_assign_ids(fem_t fe)
 {
     int numnp = fe->mesh->numnp;
     int ndof = fe->ndof;
@@ -57,7 +57,7 @@ int fem_assign_ids(fem_t* fe)
 }
 
 // Decrement U by du_red
-void fem_update_U(fem_t* fe, double* du_red)
+void fem_update_U(fem_t fe, double* du_red)
 {
     double* U = fe->U;
     int* id   = fe->id;
@@ -70,7 +70,7 @@ void fem_update_U(fem_t* fe, double* du_red)
 }
 
 // Call the callback on each nodes (node position, force vector)
-void fem_set_load(fem_t* fe, void (*f)(double* x, double* fx))
+void fem_set_load(fem_t fe, void (*f)(double* x, double* fx))
 {
     int d     = fe->mesh->d;
     int numnp = fe->mesh->numnp;
@@ -82,11 +82,11 @@ void fem_set_load(fem_t* fe, void (*f)(double* x, double* fx))
 }
 
 // Assemble global residual and tangent stiffness (general)
-void fem_assemble(fem_t* fe, double* R, assemble_t* K)
+void fem_assemble(fem_t fe, double* R, assemble_t K)
 {
     int numelt       = fe->mesh->numelt;
     int nen          = fe->mesh->nen;
-    element_t* etype = fe->etype;
+    element_t etype = fe->etype;
 
     // Set up local storage for element contributions
     int* ids   =     int_calloc(nen);
@@ -121,10 +121,10 @@ void fem_assemble(fem_t* fe, double* R, assemble_t* K)
 }
 
 // Convenience function for assembling band matrix
-void fem_assemble_band(fem_t* fe, double* R, bandmat_t* K)
+void fem_assemble_band(fem_t fe, double* R, bandmat_t K)
 {
     if (K) {
-        assemble_t Kassembler;
+        struct assemble_t Kassembler;
         init_assemble_band(&Kassembler, K);
         fem_assemble(fe, R, &Kassembler);
     } else {
@@ -133,10 +133,10 @@ void fem_assemble_band(fem_t* fe, double* R, bandmat_t* K)
 }
 
 // Convenience function for assembling dense matrix
-void fem_assemble_dense(fem_t* fe, double* R, densemat_t* K)
+void fem_assemble_dense(fem_t fe, double* R, densemat_t K)
 {
     if (K) {
-        assemble_t Kassembler;
+        struct assemble_t Kassembler;
         init_assemble_dense(&Kassembler, K);
         fem_assemble(fe, R, &Kassembler);
     } else {
@@ -145,7 +145,7 @@ void fem_assemble_dense(fem_t* fe, double* R, densemat_t* K)
 }
 
 // Print mesh state
-void fem_print(fem_t* fe)
+void fem_print(fem_t fe)
 {
     printf("\nNodal information:\n");
     printf("       ID ");

--- a/src/fem.h
+++ b/src/fem.h
@@ -36,10 +36,10 @@ struct mesh_t;
 typedef struct fem_t {
 
     // Mesh data
-    struct mesh_t* mesh;
+    struct mesh_t *mesh;
 
     // Element type (NB: can generalize with multiple types)
-    struct element_t* etype;
+    struct element_t *etype;
 
     // Storage for fields
     double* U;  // Global array of solution values (ndof-by-numnp)
@@ -50,13 +50,13 @@ typedef struct fem_t {
     int ndof;    // Number of unknowns per nodal point (tested only with ndof = 1)
     int nactive; // Number of active dofs
 
-} fem_t;
+} *fem_t;
 
 /**
  * ## Mesh operations
  */
-fem_t* fem_malloc(struct mesh_t* mesh, int ndof);
-void fem_free(fem_t* fe);
+fem_t fem_malloc(mesh_t mesh, int ndof);
+void fem_free(fem_t fe);
 
 /**
  * The `fem_assign_ids` function sets up the `id` array.  On input,
@@ -66,7 +66,7 @@ void fem_free(fem_t* fe);
  * subject to essential boundary conditions will be assigned indices from
  * 0 to `nactive` (and `nactive` will be updated appropriately).
  */
-int fem_assign_ids(fem_t* fe);
+int fem_assign_ids(fem_t fe);
 
 /**
  * The `fem_update_U` function applies an update to the internal state.
@@ -79,7 +79,7 @@ int fem_assign_ids(fem_t* fe);
  * and the same framework works for Newton iterations for nonlinear problems.
  * 
  */
-void fem_update_U(fem_t* fe, double* du_red);
+void fem_update_U(fem_t fe, double* du_red);
 
 /**
  * The `fem_set_load` function iterates through all nodes in the mesh,
@@ -87,7 +87,7 @@ void fem_update_U(fem_t* fe, double* du_red);
  * callback are the node position (an input argument) and the node
  * loading / right-hand side vector (an output argument).
  */
-void fem_set_load(fem_t* fe, void (*f)(double* x, double* fx));
+void fem_set_load(fem_t fe, void (*f)(double* x, double* fx));
 
 /**
  * The assembly loops iterate through the elements and produce a global
@@ -95,15 +95,15 @@ void fem_set_load(fem_t* fe, void (*f)(double* x, double* fx));
  * The residual and tangent matrix assembler are passed in by pointers;
  * a `NULL` pointer means "do not assemble this".
  */
-void fem_assemble(fem_t* fe, double* R, struct assemble_t* Kassembler);
-void fem_assemble_band(fem_t* fe, double* R, bandmat_t* K);
-void fem_assemble_dense(fem_t* fe, double* R, densemat_t* K);
+void fem_assemble(fem_t fe, double* R, assemble_t Kassembler);
+void fem_assemble_band(fem_t fe, double* R, bandmat_t K);
+void fem_assemble_dense(fem_t fe, double* R, densemat_t K);
 
 /**
  * For debugging small problems, it is also useful to have a routine to
  * print out all the mesh arrays.
  */
-void fem_print(fem_t* fe);
+void fem_print(fem_t fe);
 
 //ldoc off
 #endif /* FEM1D_H */

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -11,9 +11,9 @@
 /**
  * ## Memory management
  */
-mesh_t* mesh_malloc(int d, int numnp, int nen, int numelt)
+mesh_t mesh_malloc(int d, int numnp, int nen, int numelt)
 {
-    mesh_t* mesh = surely_malloc(sizeof(mesh_t));
+    mesh_t mesh = surely_malloc(sizeof(struct mesh_t));
     mesh->d      = d;
     mesh->numnp  = numnp;
     mesh->nen    = nen;
@@ -24,7 +24,7 @@ mesh_t* mesh_malloc(int d, int numnp, int nen, int numelt)
     return mesh;
 }
 
-void mesh_free(mesh_t* mesh)
+void mesh_free(mesh_t mesh)
 {
     free(mesh->elt);
     free(mesh->X);
@@ -38,11 +38,11 @@ void mesh_free(mesh_t* mesh)
  * $[a,b]$. Elements are ordered from left to right.  We allow
  * elements of order 1-3.
  */
-mesh_t* mesh_create1d(int numelt, int degree, double a, double b)
+mesh_t mesh_create1d(int numelt, int degree, double a, double b)
 {
     int numnp = numelt * degree + 1;
     int nen = degree + 1;
-    mesh_t* mesh = mesh_malloc(1, numnp, nen, numelt);
+    mesh_t mesh = mesh_malloc(1, numnp, nen, numelt);
 
     if      (degree == 1) mesh->shape = shapes1dP1;
     else if (degree == 2) mesh->shape = shapes1dP2;
@@ -73,10 +73,10 @@ mesh_t* mesh_create1d(int numelt, int degree, double a, double b)
  * 
  * We start with the P1 case, which is the simplest (only corner nodes).
  */
-mesh_t* mesh_block2d_P1(int nex, int ney)
+mesh_t mesh_block2d_P1(int nex, int ney)
 {
     int nx = nex+1, ny = ney+1;
-    mesh_t* mesh = mesh_malloc(2, nx*ny, 4, nex*ney);
+    mesh_t mesh = mesh_malloc(2, nx*ny, 4, nex*ney);
     mesh->shape = shapes2dP1;
 
     // Set up nodes (row-by-row, SW to NE)
@@ -106,10 +106,10 @@ mesh_t* mesh_block2d_P1(int nex, int ney)
  * columns of the logical array of nodes.  This at least remains
  * mostly straightforward.
  */
-mesh_t* mesh_block2d_P2(int nex, int ney)
+mesh_t mesh_block2d_P2(int nex, int ney)
 {
     int nx = 2*nex+1, ny = 2*ney+1;
-    mesh_t* mesh = mesh_malloc(2, nx*ny, 9, nex*ney);
+    mesh_t mesh = mesh_malloc(2, nx*ny, 9, nex*ney);
     mesh->shape = shapes2dP2;
 
     // Set up nodes (row-by-row, SW to NE)
@@ -144,11 +144,11 @@ mesh_t* mesh_block2d_P2(int nex, int ney)
  * than P1 or P2, because we don't have a regular grid of mesh points
  * (because we don't need mesh points in the middle of our elements.
  */
-mesh_t* mesh_block2d_S2(int nex, int ney)
+mesh_t mesh_block2d_S2(int nex, int ney)
 {
     int nx0 = 2*nex+1, nx1 = nex+1; // Even/odd row sizes
     int numnp = (ney+1)*nx0 + ney*nx1;
-    mesh_t* mesh = mesh_malloc(2, numnp, 8, nex*ney);
+    mesh_t mesh = mesh_malloc(2, numnp, 8, nex*ney);
     mesh->shape = shapes2dS2;
 
     // Set up nodes (row-by-row, SW to NE)
@@ -203,10 +203,10 @@ mesh_t* mesh_block2d_S2(int nex, int ney)
  * is comprised of two triangles with a common edge going from the
  * southeast to the northwest edge of the quad.
  */
-mesh_t* mesh_block2d_T1(int nex, int ney)
+mesh_t mesh_block2d_T1(int nex, int ney)
 {
     int nx = nex+1, ny = ney+1;
-    mesh_t* mesh = mesh_malloc(2, nx*ny, 3, 2*nex*ney);
+    mesh_t mesh = mesh_malloc(2, nx*ny, 3, 2*nex*ney);
     mesh->shape = shapes2dT1;
 
     // Set up nodes (row-by-row, SW to NE)
@@ -238,7 +238,7 @@ mesh_t* mesh_block2d_T1(int nex, int ney)
 /**
  * ## Reference to spatial mapping
  */
-void mesh_to_spatial(mesh_t* mesh, int eltid, double* xref,
+void mesh_to_spatial(mesh_t mesh, int eltid, double* xref,
                      double* x, int* ipiv, double* J,
                      double* N, double* dN)
 {
@@ -282,7 +282,7 @@ void mesh_to_spatial(mesh_t* mesh, int eltid, double* xref,
     }
 }
 
-double mesh_shapes(mesh_t* mesh, int eltid, double* x,
+double mesh_shapes(mesh_t mesh, int eltid, double* x,
                    double* N, double* dN)
 {
     // Allocate space to make a 3D element work
@@ -302,7 +302,7 @@ double mesh_shapes(mesh_t* mesh, int eltid, double* x,
 /**
  * ## I/O routines
  */
-void mesh_print_nodes(mesh_t* mesh)
+void mesh_print_nodes(mesh_t mesh)
 {
     printf("\nNodal positions:\n");
     printf("   ID ");
@@ -318,7 +318,7 @@ void mesh_print_nodes(mesh_t* mesh)
     }
 }
 
-void mesh_print_elt(mesh_t* mesh)
+void mesh_print_elt(mesh_t mesh)
 {
     printf("\nElement connectivity:\n");
     for (int i = 0; i < mesh->numelt; ++i) {
@@ -329,7 +329,7 @@ void mesh_print_elt(mesh_t* mesh)
     }
 }
 
-void mesh_print(mesh_t* mesh)
+void mesh_print(mesh_t mesh)
 {
     mesh_print_nodes(mesh);
     mesh_print_elt(mesh);

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -54,7 +54,7 @@ typedef struct mesh_t {
     // Shape function
     int (*shape)(double* N, double* dN, double* x);
 
-} mesh_t;
+} *mesh_t;
 
 /**
  * One *can* allocate objects and then work out the node positions and
@@ -66,14 +66,14 @@ typedef struct mesh_t {
  * nodes in the same location, but we will not bother with tied meshes
  * for now.
  */
-mesh_t* mesh_malloc(int d, int numnp, int nen, int numelt);
-void mesh_free(mesh_t* mesh);
+mesh_t mesh_malloc(int d, int numnp, int nen, int numelt);
+void mesh_free(mesh_t mesh);
 
 /**
  * The simplest mesher creates a 1D mesh on an interval $[a,b]$.
  * We allow elements of order 1-3.
  */
-mesh_t* mesh_create1d(int numelt, int degree, double a, double b);
+mesh_t mesh_create1d(int numelt, int degree, double a, double b);
 
 /**
  * Things are more complicated in 2D, and we have distinct mesh
@@ -81,10 +81,10 @@ mesh_t* mesh_create1d(int numelt, int degree, double a, double b);
  * described in the `shapes` module.  Each of these generates a mesh
  * of the region $[0,1]^2$ with `nex`-by-`ney` elements.
  */
-mesh_t* mesh_block2d_P1(int nex, int ney);
-mesh_t* mesh_block2d_P2(int nex, int ney);
-mesh_t* mesh_block2d_S2(int nex, int ney);
-mesh_t* mesh_block2d_T1(int nex, int ney);
+mesh_t mesh_block2d_P1(int nex, int ney);
+mesh_t mesh_block2d_P2(int nex, int ney);
+mesh_t mesh_block2d_S2(int nex, int ney);
+mesh_t mesh_block2d_T1(int nex, int ney);
 
 /**
  * Given a mesh and a point in a reference geometry (given by an
@@ -94,7 +94,7 @@ mesh_t* mesh_block2d_T1(int nex, int ney);
  * Jacobian of the reference to spatial map).  The Jacobian matrix
  * is in LU-factored form.
  */
-void mesh_to_spatial(mesh_t* mesh, int eltid, double* xref,
+void mesh_to_spatial(mesh_t mesh, int eltid, double* xref,
                      double* x, int* ipiv, double* J,
                      double* N, double* dN);
 
@@ -104,16 +104,16 @@ void mesh_to_spatial(mesh_t* mesh, int eltid, double* xref,
  * determinant.  So we provide a convenience wrapper around
  * `mesh_to_spatial` for this case.
  */
-double mesh_shapes(mesh_t* mesh, int eltid, double* x,
+double mesh_shapes(mesh_t mesh, int eltid, double* x,
                    double* N, double* dN);
 
 /**
  * For debugging, it is helpful to be able to print out all or part of
  * the mesh geometry.
  */
-void mesh_print_nodes(mesh_t* mesh);
-void mesh_print_elt(mesh_t* mesh);
-void mesh_print(mesh_t* mesh);
+void mesh_print_nodes(mesh_t mesh);
+void mesh_print_elt(mesh_t mesh);
+void mesh_print(mesh_t mesh);
 
 //ldoc off
 #endif /* MESH_H */

--- a/test/test_assemble.c
+++ b/test/test_assemble.c
@@ -5,7 +5,7 @@
 #include "bandmat.h"
 #include "assemble.h"
 
-void test_K_setup(assemble_t* assembler)
+void test_K_setup(assemble_t assembler)
 {
     double emat[] = {1.0, -1.0, -1.0, 1.0};
     int ids[2];
@@ -16,9 +16,9 @@ void test_K_setup(assemble_t* assembler)
 
 void test_Kassembly(void)
 {
-    densemat_t* A = densemat_malloc(3,3);
-    bandmat_t* P = bandmat_malloc(3,1);
-    assemble_t assembler;
+    densemat_t A = densemat_malloc(3,3);
+    bandmat_t P = bandmat_malloc(3,1);
+    struct assemble_t assembler;
 
     memset(A->data, 0xF, 9 * sizeof(double));
     memset(P->data, 0xF, 6 * sizeof(double));
@@ -40,7 +40,7 @@ void test_Kassembly(void)
 
 void test_Rassembly(void)
 {
-    densemat_t* v = densemat_malloc(3,1);
+    densemat_t v = densemat_malloc(3,1);
     double ve[] = {1.0, -1.0};
     int id[2];
 

--- a/test/test_bandmat.c
+++ b/test/test_bandmat.c
@@ -80,9 +80,9 @@ void get_xref(double* x)
 
 int main(void)
 {
-    densemat_t* A    = densemat_malloc(6, 6);
-    bandmat_t* xref = bandmat_malloc(6, 1);
-    bandmat_t* x    = bandmat_malloc(6, 1);
+    densemat_t A    = densemat_malloc(6, 6);
+    bandmat_t xref = bandmat_malloc(6, 1);
+    bandmat_t x    = bandmat_malloc(6, 1);
 
     // Get problem data
     get_Aref(A->data);
@@ -90,7 +90,7 @@ int main(void)
     get_bref(x->data);
 
     // Extract to band, factor, solve
-    bandmat_t* P = dense_to_band(A, 2);
+    bandmat_t P = dense_to_band(A, 2);
     bandmat_factor(P);
     bandmat_solve(P, x->data);
 

--- a/test/test_densemat.c
+++ b/test/test_densemat.c
@@ -8,7 +8,7 @@
 int main(void)
 {
     int ipiv[3];
-    densemat_t* x = densemat_malloc(3, 1);
+    densemat_t x = densemat_malloc(3, 1);
 
     // Check dimension setup
     assert(x->m == 3);
@@ -20,7 +20,7 @@ int main(void)
     assert(densemat_norm(x) == 0.0);
 
     // Check Cholesky factorization of a reference matrix
-    densemat_t* A = densemat_malloc(3, 3);
+    densemat_t A = densemat_malloc(3, 3);
     A->data[0] = 1.0;  A->data[1] =  2.0;  A->data[2] =  3.0;
     A->data[3] = 2.0;  A->data[4] = 20.0;  A->data[5] = 26.0;
     A->data[6] = 3.0;  A->data[7] = 26.0;  A->data[8] = 70.0;

--- a/test/test_fem1d.c
+++ b/test/test_fem1d.c
@@ -13,10 +13,10 @@
 
 
 // Set up the mesh on [0,1] with Dirichlet BC
-fem_t* setup_test_mesh(int numelt, int degree, double u0, double u1)
+fem_t setup_test_mesh(int numelt, int degree, double u0, double u1)
 {
-    mesh_t* mesh = mesh_create1d(numelt, degree, 0.0, 1.0);
-    fem_t* fe = fem_malloc(mesh, 1);
+    mesh_t mesh = mesh_create1d(numelt, degree, 0.0, 1.0);
+    fem_t fe = fem_malloc(mesh, 1);
     int numnp = fe->mesh->numnp;
     fe->id[0]       = -1;
     fe->id[numnp-1] = -1;
@@ -28,12 +28,12 @@ fem_t* setup_test_mesh(int numelt, int degree, double u0, double u1)
 
 void test_fem1(int d)
 {
-    fem_t* fe = setup_test_mesh(6, d, 0.0, 1.0);
+    fem_t fe = setup_test_mesh(6, d, 0.0, 1.0);
     fe->etype = malloc_poisson1d_element();
 
     // Set up globals and assemble system
-    densemat_t* R = densemat_malloc(fe->nactive, 1);
-    bandmat_t* K = bandmat_malloc(fe->nactive, d);
+    densemat_t R = densemat_malloc(fe->nactive, 1);
+    bandmat_t K = bandmat_malloc(fe->nactive, d);
     fem_assemble_band(fe, R->data, K);
 
     // Factor, solve, and update
@@ -59,13 +59,13 @@ void rhs_const1(double* x, double* fx)
 
 void test_fem2(int d)
 {
-    fem_t* fe = setup_test_mesh(6, d, 0.0, 0.0);
+    fem_t fe = setup_test_mesh(6, d, 0.0, 0.0);
     fe->etype = malloc_poisson1d_element();
     fem_set_load(fe, rhs_const1);
 
     // Set up globals and assemble system
-    densemat_t* R = densemat_malloc(fe->nactive, 1);
-    bandmat_t* K = bandmat_malloc(fe->nactive, d);
+    densemat_t R = densemat_malloc(fe->nactive, 1);
+    bandmat_t K = bandmat_malloc(fe->nactive, d);
     fem_assemble_band(fe, R->data, K);
 
     // Factor, solve, and update

--- a/test/test_fem2d.c
+++ b/test/test_fem2d.c
@@ -15,8 +15,8 @@
 // Set up the mesh on [0,1]^2 with Dirichlet BC
 void test_fem1(void)
 {
-    mesh_t* mesh = mesh_block2d_P1(2, 2);
-    fem_t* fe = fem_malloc(mesh, 1);
+    mesh_t mesh = mesh_block2d_P1(2, 2);
+    fem_t fe = fem_malloc(mesh, 1);
     fe->etype = malloc_poisson2d_element();
 
     // Move midpoint to off center (patch test!)
@@ -36,8 +36,8 @@ void test_fem1(void)
     fem_assign_ids(fe);
 
     // Set up globals and assemble system
-    densemat_t* R = densemat_malloc(fe->nactive, 1);
-    densemat_t* K = densemat_malloc(fe->nactive, fe->nactive);
+    densemat_t R = densemat_malloc(fe->nactive, 1);
+    densemat_t K = densemat_malloc(fe->nactive, fe->nactive);
     fem_assemble_dense(fe, R->data, K);
 
     // Factor, solve, and update

--- a/test/test_mesh.c
+++ b/test/test_mesh.c
@@ -87,7 +87,7 @@ static int erefT1[] = {
     6,   7,  10,
    10,   7,  11};
 
-void check_mesh(mesh_t* mesh, 
+void check_mesh(mesh_t mesh, 
                 int numnp, double* Xref,
                 int numelt, int nen, int* eref)
 {
@@ -104,7 +104,7 @@ void check_mesh(mesh_t* mesh,
 
 void test_block_meshers(void)
 {
-    mesh_t* mesh = mesh_block2d_P1(3,2);
+    mesh_t mesh = mesh_block2d_P1(3,2);
     check_mesh(mesh, 12, XrefP1, 6, 4, erefP1);
     mesh_free(mesh);
 
@@ -135,7 +135,7 @@ void test_emap(void)
     double N[4], dN[4*2], xymap[2], J[2*2];
     double xyref[] = {0.5, 1.0};
 
-    mesh_t* mesh = mesh_block2d_P1(1, 1);
+    mesh_t mesh = mesh_block2d_P1(1, 1);
 
     // Trivial mapping ([-1,1]^2 ref domain to [0,1] mesh domain)
     mesh_to_spatial(mesh, 0, xyref, xymap, ipiv, J, N, dN);

--- a/test/test_shapes.c
+++ b/test/test_shapes.c
@@ -8,7 +8,7 @@
 
 void test_shape(shapes_t shape, double* nodes, int d, int numnodes)
 {
-    densemat_t* N = densemat_malloc(numnodes,1);
+    densemat_t N = densemat_malloc(numnodes,1);
     for (int i = 0; i < numnodes; ++i) {
         shape(N->data, NULL, nodes+i*d);
         N->data[i] -= 1.0;
@@ -20,9 +20,9 @@ void test_shape(shapes_t shape, double* nodes, int d, int numnodes)
 
 void test_dshape(shapes_t shape, double* x0, int d, int numnodes)
 {
-    densemat_t* Np = densemat_malloc(numnodes,1);
-    densemat_t* Nm = densemat_malloc(numnodes,1);
-    densemat_t* dN = densemat_malloc(numnodes,d);
+    densemat_t Np = densemat_malloc(numnodes,1);
+    densemat_t Nm = densemat_malloc(numnodes,1);
+    densemat_t dN = densemat_malloc(numnodes,d);
     double h = 1e-6;
 
     double xp[3], xm[3];


### PR DESCRIPTION
1. Generally instead of
```
typedef struct foo_t { . . . } foo_t;
```
do this:
```
typedef struct foo_t { . . . } *foo_t;
```
Consequently every place there was a `foo_t*` there's now a `foo_t`.

This change is entirely cosmetic -- the C code is effectively unchanged -- but it is my preferred way of handling abstract types in C.

2.  All the places where we do   `A->data[i+j*m]`, I propose
  we do `densemat_get(A,i,j)` instead.  This will make the proofs
  go much smoother, because we can abstract (and prove about)
  column-major indexing just once, instead of every time.
  For such addressing I propose we define:
```
  double densemat_get(densemat_t dm, int i, int j);
  void densemat_set(densemat_t dm, int i, int j, double x);
  void densemat_addto(densemat_t dm, int i, int j, double x);
```

  There's another reason the proofs will really abhor the expression
  `A->data[i+j*m]`.  Normally VST can handle such an expression OK,
  but in this case we are also playing the trick that `A->data`, is
  a zero-length array with ad-hoc extras added at each malloc.
  One can reason about this in VST, but the automated reasoning can't
  handle it, so the proof is quite laborious.  If we abstract
  array-indexing into these functions, then that laborious proof
  needs to be done only once.  (Well, three times, anyway.)